### PR TITLE
Change in Periods API

### DIFF
--- a/StatusCake.Client/Models/Period.cs
+++ b/StatusCake.Client/Models/Period.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace StatusCake.Client.Models
 {
@@ -24,6 +25,17 @@ namespace StatusCake.Client.Models
         /// <summary>
         /// The status type
         /// </summary>
-        public string Up { get; set; }
+        public string Status { get; set; }
+
+        /// <summary>
+        /// Additional information
+        /// </summary>
+        public string Additional { get; set; }
+
+        /// <summary>
+        /// Period time in text
+        /// </summary>
+        [JsonProperty("Period")]
+        public string PeriodText { get; set; }
     }
 }


### PR DESCRIPTION
They've changed "Up" to "Status" and added two new fields. "Addtional" which holds extra information about the period and "Period" (which I've named "PeriodText" not to break anything, which holds the time in text format.
